### PR TITLE
since ccsrch.h is removed, CMakeLists.txt should be updated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(ccsrch)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 set(SOURCE_FILES
-    ccsrch.c
-    ccsrch.h)
+    ccsrch.c)
 
 add_executable(ccsrch ${SOURCE_FILES})


### PR DESCRIPTION
The ccsrch.h is removed and to make cmake available, the CMakeLists.txt should also remove that file.